### PR TITLE
Allow to send email through different port than 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Cloud.cloudrestore(u"YOUR MODEL NAME (lowercase only)")
 
 The Docker container requires at least 2 CPUs, 4 GB, 4 GB of RAM / Storage. This is due to the fact that it is runs FreeCAD and minio locally.
 
-Please edit the `start_container` file and add the following data to your relevant server
+Please edit the `start_container` file and add the following data to your relevant server ( the SMTP_SERVER must include the port name -> <myserver:25 or myserver:587> as an example )
 
 ```bash
 export SMTP_SERVER=

--- a/src/base/base.go
+++ b/src/base/base.go
@@ -115,7 +115,9 @@ var smtpAccount =  os.Getenv("SMTP_ACCOUNT")
 var smtpPassword = os.Getenv("SMTP_PASSWORD")
 
 func SendEmail(email string, subject string, validationString string) {
-    from := mail.Address{"", smtpAccount+"@"+smtpServer}
+    servername := smtpServer
+    host, _, _ := net.SplitHostPort(servername)
+    from := mail.Address{"", smtpAccount+"@"+host}
     to   := mail.Address{"", email}
     subj := subject
     body := validationString
@@ -134,9 +136,6 @@ func SendEmail(email string, subject string, validationString string) {
     message += "\r\n" + body
 
     // Connect to the SMTP Server
-    servername := smtpServer+":25"
-
-    host, _, _ := net.SplitHostPort(servername)
 
     auth := smtp.PlainAuth("",smtpAccount, smtpPassword, host)
 


### PR DESCRIPTION
Some ISP doesn't allow to do that which is disabling the ability to
test the docker image